### PR TITLE
Update docbook jar version

### DIFF
--- a/doc/build.gradle
+++ b/doc/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 plugins {
     id 'java-library'
     id 'org.neo4j.doc.build.saxon' version '1.0-alpha02'
-    id 'org.neo4j.doc.build.docbook' version '1.0-alpha11'
+    id 'org.neo4j.doc.build.docbook' version '1.0-alpha15'
 }
 
 description = 'Neo4j Graph Data Science :: Docs'


### PR DESCRIPTION
This change updates the docbook jar version that is used to build the Graph Data Science manual. The new version adds a meta tag to the output for new search function