### PR TITLE
Fixed issue 81 (Parameter "maxIterations" is ignored in Louvain Community Detection algo)

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/louvain/Louvain.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/louvain/Louvain.java
@@ -149,7 +149,7 @@ public final class Louvain extends Algorithm<Louvain, Louvain> {
     private ModularityOptimization runModularityOptimization(Graph louvainGraph, NodeProperties seed) {
         ModularityOptimizationStreamConfig modularityOptimizationConfig = ImmutableModularityOptimizationStreamConfig
             .builder()
-            .maxIterations(10)
+            .maxIterations(config.maxIterations())
             .tolerance(config.tolerance())
             .concurrency(config.concurrency())
             .batchSize(DEFAULT_BATCH_SIZE)


### PR DESCRIPTION
Issue 81: https://github.com/neo4j/graph-data-science/issues/81

Louvain algorithm consists of two phases, which themselves get repeated until the gained Modularity is insignificant.

The first phase of these two phases is where each node tries to detach itself from its current Community and attach to the neighbor Community, which gives the highest Modularity Gain (ΔQ). This phase is run iteratively and the `maxIterations` is used to control how many iterations to run. There might be chances that the graph needs more than 10 iterations to converge; thus, users should have the right to adjust this parameter if that's the case.