### PR TITLE
feat: add progress tacker logger to pregel context

### DIFF
--- a/doc/asciidoc/algorithms/algorithms-pregel-api.adoc
+++ b/doc/asciidoc/algorithms/algorithms-pregel-api.adoc
@@ -349,6 +349,34 @@ public class CustomComputation implements PregelComputation<CustomConfig> {
 }
 ----
 
+[[algorithms-pregel-api-logging]]
+=== Logging
+
+The following methods are available for all contexts (`InitContext`, `ComputeContext`, `MasterComputeContext`) to inject custom messages into the progress log of the algorithm execution.
+
+.The log methods can be used in Pregel contexts
+[source, java]
+----
+// All contexts inherit from PregelContext
+public abstract class PregelContext<CONFIG extends PregelConfig> {
+
+    // Log a debug message to the Neo4j log.
+    public void logDebug(String message) {
+        progressTracker.logDebug(message);
+    }
+
+    // Log a warning message to the Neo4j log.
+    public void logWarning(String message) {
+        progressTracker.logWarning(message);
+    }
+
+    // Log a info message to the Neo4j log
+    public void logMessage(String message) {
+        progressTracker.logMessage(message);
+    }
+
+}
+----
 
 [[algorithms-pregel-api-procedure]]
 == Run Pregel via Cypher

--- a/pregel/src/main/java/org/neo4j/gds/beta/pregel/ForkJoinComputeStep.java
+++ b/pregel/src/main/java/org/neo4j/gds/beta/pregel/ForkJoinComputeStep.java
@@ -75,10 +75,10 @@ public final class ForkJoinComputeStep<CONFIG extends PregelConfig, ITERATOR ext
         this.nodeBatch = nodeBatch;
         this.nodeValue = nodeValue;
         this.messenger = messenger;
-        this.computeContext = new ComputeContext<>(this, config);
+        this.computeContext = new ComputeContext<>(this, config, progressTracker);
         this.sentMessage = sentMessage;
         this.progressTracker = progressTracker;
-        this.initContext = new InitContext<>(this, config, graph);
+        this.initContext = new InitContext<>(this, config, graph, progressTracker);
     }
 
     @Override

--- a/pregel/src/main/java/org/neo4j/gds/beta/pregel/PartitionedComputeStep.java
+++ b/pregel/src/main/java/org/neo4j/gds/beta/pregel/PartitionedComputeStep.java
@@ -60,9 +60,9 @@ public final class PartitionedComputeStep<CONFIG extends PregelConfig, ITERATOR 
         this.voteBits = voteBits;
         this.nodeBatch = nodeBatch;
         this.messenger = messenger;
-        this.computeContext = new ComputeContext<>(this, config);
+        this.computeContext = new ComputeContext<>(this, config, progressTracker);
         this.progressTracker = progressTracker;
-        this.initContext = new InitContext<>(this, config, graph);
+        this.initContext = new InitContext<>(this, config, graph, progressTracker);
     }
 
     @Override

--- a/pregel/src/main/java/org/neo4j/gds/beta/pregel/Pregel.java
+++ b/pregel/src/main/java/org/neo4j/gds/beta/pregel/Pregel.java
@@ -200,7 +200,7 @@ public final class Pregel<CONFIG extends PregelConfig> {
     }
 
     private boolean runMasterComputeStep(int iteration) {
-        var context = new MasterComputeContext<>(config, graph, iteration, nodeValues, executor);
+        var context = new MasterComputeContext<>(config, graph, iteration, nodeValues, executor, progressTracker);
         var didConverge = computation.masterCompute(context);
         return didConverge;
     }

--- a/pregel/src/main/java/org/neo4j/gds/beta/pregel/context/ComputeContext.java
+++ b/pregel/src/main/java/org/neo4j/gds/beta/pregel/context/ComputeContext.java
@@ -21,6 +21,7 @@ package org.neo4j.gds.beta.pregel.context;
 
 import org.neo4j.gds.beta.pregel.ComputeStep;
 import org.neo4j.gds.beta.pregel.PregelConfig;
+import org.neo4j.gds.core.utils.progress.tasks.ProgressTracker;
 
 /**
  * A context that is used during the computation. It allows an implementation
@@ -29,8 +30,8 @@ import org.neo4j.gds.beta.pregel.PregelConfig;
  */
 public final class ComputeContext<CONFIG extends PregelConfig> extends NodeCentricContext<CONFIG> {
 
-    public ComputeContext(ComputeStep<CONFIG, ?> computeStep, CONFIG config) {
-        super(computeStep, config);
+    public ComputeContext(ComputeStep<CONFIG, ?> computeStep, CONFIG config, ProgressTracker progressTracker) {
+        super(computeStep, config, progressTracker);
         this.sendMessagesFunction = config.hasRelationshipWeightProperty()
             ? computeStep::sendToNeighborsWeighted
             : computeStep::sendToNeighbors;

--- a/pregel/src/main/java/org/neo4j/gds/beta/pregel/context/InitContext.java
+++ b/pregel/src/main/java/org/neo4j/gds/beta/pregel/context/InitContext.java
@@ -23,6 +23,7 @@ import org.neo4j.gds.api.NodeProperties;
 import org.neo4j.gds.api.NodePropertyContainer;
 import org.neo4j.gds.beta.pregel.ComputeStep;
 import org.neo4j.gds.beta.pregel.PregelConfig;
+import org.neo4j.gds.core.utils.progress.tasks.ProgressTracker;
 
 import java.util.Set;
 
@@ -35,8 +36,13 @@ import java.util.Set;
 public final class InitContext<CONFIG extends PregelConfig> extends NodeCentricContext<CONFIG> {
     private final NodePropertyContainer nodePropertyContainer;
 
-    public InitContext(ComputeStep<CONFIG, ?> computeStep, CONFIG config, NodePropertyContainer nodePropertyContainer) {
-        super(computeStep, config);
+    public InitContext(
+        ComputeStep<CONFIG, ?> computeStep,
+        CONFIG config,
+        NodePropertyContainer nodePropertyContainer,
+        ProgressTracker progressTracker
+    ) {
+        super(computeStep, config, progressTracker);
         this.nodePropertyContainer = nodePropertyContainer;
     }
 

--- a/pregel/src/main/java/org/neo4j/gds/beta/pregel/context/MasterComputeContext.java
+++ b/pregel/src/main/java/org/neo4j/gds/beta/pregel/context/MasterComputeContext.java
@@ -22,6 +22,7 @@ package org.neo4j.gds.beta.pregel.context;
 import org.neo4j.gds.api.Graph;
 import org.neo4j.gds.beta.pregel.NodeValue;
 import org.neo4j.gds.beta.pregel.PregelConfig;
+import org.neo4j.gds.core.utils.progress.tasks.ProgressTracker;
 
 import java.util.concurrent.ExecutorService;
 import java.util.function.LongPredicate;
@@ -39,9 +40,10 @@ public class MasterComputeContext<CONFIG extends PregelConfig> extends PregelCon
         Graph graph,
         int iteration,
         NodeValue nodeValue,
-        ExecutorService executorService
+        ExecutorService executorService,
+        ProgressTracker progressTracker
     ) {
-        super(config);
+        super(config, progressTracker);
         this.graph = graph;
         this.iteration = iteration;
         this.nodeValue = nodeValue;

--- a/pregel/src/main/java/org/neo4j/gds/beta/pregel/context/NodeCentricContext.java
+++ b/pregel/src/main/java/org/neo4j/gds/beta/pregel/context/NodeCentricContext.java
@@ -21,6 +21,7 @@ package org.neo4j.gds.beta.pregel.context;
 
 import org.neo4j.gds.beta.pregel.ComputeStep;
 import org.neo4j.gds.beta.pregel.PregelConfig;
+import org.neo4j.gds.core.utils.progress.tasks.ProgressTracker;
 
 import java.util.function.LongConsumer;
 
@@ -30,8 +31,8 @@ public abstract class NodeCentricContext<CONFIG extends PregelConfig> extends Pr
 
     long nodeId;
 
-    NodeCentricContext(ComputeStep<CONFIG, ?> computeStep, CONFIG config) {
-        super(config);
+    NodeCentricContext(ComputeStep<CONFIG, ?> computeStep, CONFIG config, ProgressTracker progressTracker) {
+        super(config, progressTracker);
         this.computeStep = computeStep;
     }
 

--- a/pregel/src/main/java/org/neo4j/gds/beta/pregel/context/PregelContext.java
+++ b/pregel/src/main/java/org/neo4j/gds/beta/pregel/context/PregelContext.java
@@ -20,13 +20,16 @@
 package org.neo4j.gds.beta.pregel.context;
 
 import org.neo4j.gds.beta.pregel.PregelConfig;
+import org.neo4j.gds.core.utils.progress.tasks.ProgressTracker;
 
 public abstract class PregelContext<CONFIG extends PregelConfig> {
 
     protected final CONFIG config;
+    private final ProgressTracker progressTracker;
 
-    protected PregelContext(CONFIG config) {
+    protected PregelContext(CONFIG config, ProgressTracker progressTracker) {
         this.config = config;
+        this.progressTracker = progressTracker;
     }
 
     /**
@@ -34,6 +37,27 @@ public abstract class PregelContext<CONFIG extends PregelConfig> {
      */
     public CONFIG config() {
         return config;
+    }
+
+    /**
+     * Log a debug message to the Neo4j log.
+     */
+    public void logDebug(String message) {
+        progressTracker.logDebug(message);
+    }
+
+    /**
+     * Log a warning message to the Neo4j log.
+     */
+    public void logWarning(String message) {
+        progressTracker.logWarning(message);
+    }
+
+    /**
+     * Log a info message to the Neo4j log
+     */
+    public void logMessage(String message) {
+        progressTracker.logMessage(message);
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

<!-- Please include a summary of the change, such as, which issue was fixed or feature was added. 
If relevant, link to the corresponding issue.
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please make sure:
- [x] You signed the [Neo4j CLA](https://neo4j.com/developer/cla/#sign-cla) (Contributor License Agreement) so that we are allowed to ship your code in our library
- [ ] Your contribution is covered by tests

This PR tends to add a build-in logger to Pregel framework. close #180 

I looked into the code and `InitContext` and `ComputeContext` derive from `NodeCentricContext` which derives from `PregelContext`. And `MasterComputeContext` derives from `PregelContext`, so I add a private `ProgressTracker` reference into the `PregelContext` and expose three public functions `logDebug`, `logWarning` and `logMessage` which will call the same functions in the tracker, so developers can use them in all three contexts in the framework.

What I am not sure is:

- How to add or should I add test case to this PR?