### PR TITLE
Fixed windows tests failing due to CR;LF issues

### DIFF
--- a/algo/src/test/java/org/neo4j/gds/similarity/nodesim/NodeSimilarityTest.java
+++ b/algo/src/test/java/org/neo4j/gds/similarity/nodesim/NodeSimilarityTest.java
@@ -77,6 +77,8 @@ import static org.neo4j.gds.utils.StringFormatting.formatWithLocale;
 @GdlExtension
 final class NodeSimilarityTest {
 
+    private static final String newLine = System.lineSeparator();
+
     @GdlGraph(graphNamePrefix = "natural", orientation = NATURAL)
     @GdlGraph(graphNamePrefix = "reverse", orientation = REVERSE)
     @GdlGraph(graphNamePrefix = "undirected", orientation = UNDIRECTED)
@@ -881,7 +883,7 @@ final class NodeSimilarityTest {
             .map(NodeSimilarityTest::resultString)
             .collect(Collectors.toSet());
 
-        assertThat(result).contains("0,1 0.500000\n" );
+        assertThat(result).contains("0,1 0.500000" + newLine);
 
         nodeSimilarity = new NodeSimilarity(
             graph,
@@ -895,7 +897,7 @@ final class NodeSimilarityTest {
             .map(NodeSimilarityTest::resultString)
             .collect(Collectors.toSet());
 
-        assertThat(result).contains("0,1 0.333333\n" );
+        assertThat(result).contains("0,1 0.333333" + newLine);
 
     }
 

--- a/alpha/alpha-proc/src/test/java/org/neo4j/gds/scc/SccDocTest.java
+++ b/alpha/alpha-proc/src/test/java/org/neo4j/gds/scc/SccDocTest.java
@@ -48,6 +48,8 @@ class SccDocTest extends BaseProcTest {
         "CREATE (nBridget)-[:FOLLOW]->(nAlice) " +
         "CREATE (nMichael)-[:FOLLOW]->(nBridget); ";
 
+    private static final String newLine = System.lineSeparator();
+
     @BeforeEach
     void setup() throws Exception {
         runQuery(DB_CYPHER);
@@ -64,17 +66,17 @@ class SccDocTest extends BaseProcTest {
                        "RETURN gds.util.asNode(nodeId).name AS Name, componentId AS Component " +
                        "ORDER BY Component DESC";
 
-        String expected = "+-----------------------+\n" +
-                          "| Name      | Component |\n" +
-                          "+-----------------------+\n" +
-                          "| \"Doug\"    | 3         |\n" +
-                          "| \"Mark\"    | 3         |\n" +
-                          "| \"Charles\" | 2         |\n" +
-                          "| \"Alice\"   | 0         |\n" +
-                          "| \"Bridget\" | 0         |\n" +
-                          "| \"Michael\" | 0         |\n" +
-                          "+-----------------------+\n" +
-                          "6 rows\n";
+        String expected = "+-----------------------+" + newLine +
+                          "| Name      | Component |" + newLine +
+                          "+-----------------------+" + newLine +
+                          "| \"Doug\"    | 3         |" + newLine +
+                          "| \"Mark\"    | 3         |" + newLine +
+                          "| \"Charles\" | 2         |" + newLine +
+                          "| \"Alice\"   | 0         |" + newLine +
+                          "| \"Bridget\" | 0         |" + newLine +
+                          "| \"Michael\" | 0         |" + newLine +
+                          "+-----------------------+" + newLine +
+                          "6 rows" + newLine;
 
         assertEquals(expected, runQuery(query, Result::resultAsString));
     }
@@ -86,12 +88,12 @@ class SccDocTest extends BaseProcTest {
                        "}) " +
                        "YIELD setCount, maxSetSize, minSetSize; ";
 
-        String expected = "+------------------------------------+\n" +
-                          "| setCount | maxSetSize | minSetSize |\n" +
-                          "+------------------------------------+\n" +
-                          "| 3        | 3          | 1          |\n" +
-                          "+------------------------------------+\n" +
-                          "1 row\n";
+        String expected = "+------------------------------------+" + newLine +
+                          "| setCount | maxSetSize | minSetSize |" + newLine +
+                          "+------------------------------------+" + newLine +
+                          "| 3        | 3          | 1          |" + newLine +
+                          "+------------------------------------+" + newLine +
+                          "1 row" + newLine;
 
         assertEquals(expected, runQuery(query, Result::resultAsString));
     }
@@ -109,12 +111,12 @@ class SccDocTest extends BaseProcTest {
                        "ORDER BY PartitionSize DESC " +
                        "LIMIT 1 ";
 
-        String expected = "+---------------------------+\n" +
-                          "| Component | PartitionSize |\n" +
-                          "+---------------------------+\n" +
-                          "| 0         | 3             |\n" +
-                          "+---------------------------+\n" +
-                          "1 row\n";
+        String expected = "+---------------------------+" + newLine +
+                          "| Component | PartitionSize |" + newLine +
+                          "+---------------------------+" + newLine +
+                          "| 0         | 3             |" + newLine +
+                          "+---------------------------+" + newLine +
+                          "1 row" + newLine;
 
         assertEquals(expected, runQuery(query, Result::resultAsString));
     }

--- a/doc-test/src/test/java/org/neo4j/gds/doc/syntax/ProcedureSyntaxAutoCheckerTest.java
+++ b/doc-test/src/test/java/org/neo4j/gds/doc/syntax/ProcedureSyntaxAutoCheckerTest.java
@@ -46,6 +46,8 @@ class ProcedureSyntaxAutoCheckerTest {
     private File outputDirectory;
     private OptionsBuilder options;
 
+    private static final String newLine = System.lineSeparator();
+
     @BeforeEach
     void setUp() {
         // By default we are forced to use relative path which we don't want.
@@ -149,7 +151,7 @@ class ProcedureSyntaxAutoCheckerTest {
             .hasSize(1)
             .allSatisfy(assertionError -> assertThat(assertionError)
                 .hasMessageContaining("Asserting YIELD result columns for `include-with-stream`")
-                .hasMessageContaining("could not find the following elements:\n" +
+                .hasMessageContaining("could not find the following elements:" + newLine +
                                       "  [\"communityId\", \"intermediateCommunityIds\"]"));
     }
 
@@ -172,7 +174,7 @@ class ProcedureSyntaxAutoCheckerTest {
             .hasSize(1)
             .allSatisfy(assertionError -> assertThat(assertionError)
                 .hasMessageContaining("Asserting YIELD result columns for `include-with-stream`")
-                .hasMessageContaining("the following elements were unexpected:\n" +
+                .hasMessageContaining("the following elements were unexpected:" + newLine +
                                       "  [\"bogusResultColumn\"]"));
     }
 
@@ -195,7 +197,7 @@ class ProcedureSyntaxAutoCheckerTest {
             .hasSize(1)
             .allSatisfy(assertionError -> assertThat(assertionError)
                 .hasMessageContaining("Asserting `Results` table for `include-with-stream`")
-                .hasMessageContaining("could not find the following elements:\n" +
+                .hasMessageContaining("could not find the following elements:" + newLine +
                                       "  [\"intermediateCommunityIds\"]"));
     }
 
@@ -218,7 +220,7 @@ class ProcedureSyntaxAutoCheckerTest {
             .hasSize(1)
             .allSatisfy(assertionError -> assertThat(assertionError)
                 .hasMessageContaining("Asserting `Results` table for `include-with-stream`")
-                .hasMessageContaining("the following elements were unexpected:\n" +
+                .hasMessageContaining("the following elements were unexpected:" + newLine +
                                       "  [\"bogusResultColumn\"]"));
     }
 

--- a/proc/catalog/src/test/java/org/neo4j/gds/catalog/ConfigKeyValidationTest.java
+++ b/proc/catalog/src/test/java/org/neo4j/gds/catalog/ConfigKeyValidationTest.java
@@ -32,6 +32,8 @@ import static org.neo4j.gds.utils.StringFormatting.formatWithLocale;
 
 class ConfigKeyValidationTest extends BaseProcTest {
 
+    private static final String newLine = System.lineSeparator();
+
     @BeforeEach
     void setup() throws Exception {
         registerProcedures(GraphProjectProc.class, TestProc.class);
@@ -145,8 +147,8 @@ class ConfigKeyValidationTest extends BaseProcTest {
             () -> runQuery(formatWithLocale("CALL gds.testProc.write('%s', {maxIterations: [1]})", DEFAULT_GRAPH_NAME))
         );
 
-        String expectedMsg = "Multiple errors in configuration arguments:\n" +
-                             "\t\t\t\tThe value of `maxIterations` must be of type `Integer` but was `ArrayList`.\n" +
+        String expectedMsg = "Multiple errors in configuration arguments:" + newLine +
+                             "\t\t\t\tThe value of `maxIterations` must be of type `Integer` but was `ArrayList`." + newLine +
                              "\t\t\t\tNo value specified for the mandatory configuration parameter `writeProperty`";
         assertThat(
             exception,

--- a/proc/catalog/src/test/java/org/neo4j/gds/catalog/GraphProjectProcTest.java
+++ b/proc/catalog/src/test/java/org/neo4j/gds/catalog/GraphProjectProcTest.java
@@ -103,6 +103,7 @@ import static org.neo4j.gds.utils.StringFormatting.formatWithLocale;
 class GraphProjectProcTest extends BaseProcTest {
 
     private static final String DB_CYPHER = "CREATE (:A {age: 2})-[:REL {weight: 55}]->(:A)";
+    private static final String newLine = System.lineSeparator();
 
     @BeforeEach
     void setup() throws Exception {
@@ -1188,8 +1189,8 @@ class GraphProjectProcTest extends BaseProcTest {
     void failsOnBothEmptyProjection() {
         String query = "CALL gds.graph.project('g','','')";
 
-        String expectedMsg = "Multiple errors in configuration arguments:\n" +
-                             "\t\t\t\tAn empty node projection was given; at least one node label must be projected.\n" +
+        String expectedMsg = "Multiple errors in configuration arguments:" + newLine +
+                             "\t\t\t\tAn empty node projection was given; at least one node label must be projected." + newLine +
                              "\t\t\t\tAn empty relationship projection was given; at least one relationship type must be projected.";
 
         assertError(

--- a/proc/machine-learning/src/test/java/org/neo4j/gds/ml/linkmodels/pipeline/LinkPredictionPipelineAddTrainerMethodProcsTest.java
+++ b/proc/machine-learning/src/test/java/org/neo4j/gds/ml/linkmodels/pipeline/LinkPredictionPipelineAddTrainerMethodProcsTest.java
@@ -36,6 +36,8 @@ import static org.neo4j.gds.ml.linkmodels.pipeline.LinkPredictionPipelineAddStep
 
 class LinkPredictionPipelineAddTrainerMethodProcsTest extends BaseProcTest {
 
+    private static final String newLine = System.lineSeparator();
+
     @BeforeEach
     void setUp() throws Exception {
         registerProcedures(LinkPredictionPipelineAddTrainerMethodProcs.class, LinkPredictionPipelineCreateProc.class);
@@ -146,8 +148,8 @@ class LinkPredictionPipelineAddTrainerMethodProcsTest extends BaseProcTest {
     void failOnInvalidParameterValues() {
         assertError(
             "CALL gds.beta.pipeline.linkPrediction.addLogisticRegression('myPipeline', {minEpochs: 0.5, batchSize: 0.51})",
-            "Multiple errors in configuration arguments:\n" +
-            "\t\t\t\tThe value of `batchSize` must be of type `Integer` but was `Double`.\n" +
+            "Multiple errors in configuration arguments:" + newLine +
+            "\t\t\t\tThe value of `batchSize` must be of type `Integer` but was `Double`." + newLine +
             "\t\t\t\tThe value of `minEpochs` must be of type `Integer` but was `Double`."
         );
     }

--- a/proc/machine-learning/src/test/java/org/neo4j/gds/ml/pipeline/node/classification/NodeClassificationPipelineAddTrainerMethodProcsTest.java
+++ b/proc/machine-learning/src/test/java/org/neo4j/gds/ml/pipeline/node/classification/NodeClassificationPipelineAddTrainerMethodProcsTest.java
@@ -35,6 +35,8 @@ import static org.neo4j.gds.ml.pipeline.AutoTuningConfig.MAX_TRIALS;
 
 class NodeClassificationPipelineAddTrainerMethodProcsTest extends BaseProcTest {
 
+    private static final String newLine = System.lineSeparator();
+
     @BeforeEach
     void setUp() throws Exception {
         registerProcedures(NodeClassificationPipelineAddTrainerMethodProcs.class, NodeClassificationPipelineCreateProc.class);
@@ -143,8 +145,8 @@ class NodeClassificationPipelineAddTrainerMethodProcsTest extends BaseProcTest {
     void failOnInvalidParameterValues() {
         assertError(
             "CALL gds.beta.pipeline.nodeClassification.addLogisticRegression('myPipeline', {minEpochs: 0.5, batchSize: 0.51})",
-            "Multiple errors in configuration arguments:\n" +
-            "\t\t\t\tThe value of `batchSize` must be of type `Integer` but was `Double`.\n" +
+            "Multiple errors in configuration arguments:" + newLine +
+            "\t\t\t\tThe value of `batchSize` must be of type `Integer` but was `Double`." + newLine +
             "\t\t\t\tThe value of `minEpochs` must be of type `Integer` but was `Double`."
         );
     }

--- a/test-utils/src/test/java/org/neo4j/gds/core/CypherExporterTest.java
+++ b/test-utils/src/test/java/org/neo4j/gds/core/CypherExporterTest.java
@@ -34,17 +34,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 final class CypherExporterTest extends BaseTest {
 
+    private static final String newLine = System.lineSeparator();
+
     @BeforeEach
     void setup() {
         String createGraph =
-                "CREATE (nA:Label1 { foo: 'bar' })\n" +
-                "CREATE (nB:Label1 { property: 42.1337 })\n" +
-                "CREATE (nC:Label2)\n" +
-                "CREATE (nD)\n" +
-                "CREATE\n" +
-                "  (nA)-[:TYPE1 {bar: 'baz'}]->(nB),\n" +
-                "  (nA)-[:TYPE1 {property:1337.42}]->(nC),\n" +
-                "  (nB)-[:TYPE2]->(nC),\n" +
+                "CREATE (nA:Label1 { foo: 'bar' })" + newLine +
+                "CREATE (nB:Label1 { property: 42.1337 })" + newLine +
+                "CREATE (nC:Label2)" + newLine +
+                "CREATE (nD)" + newLine +
+                "CREATE" + newLine +
+                "  (nA)-[:TYPE1 {bar: 'baz'}]->(nB)," + newLine +
+                "  (nA)-[:TYPE1 {property:1337.42}]->(nC)," + newLine +
+                "  (nB)-[:TYPE2]->(nC)," + newLine +
                 "  (nC)-[:TYPE]->(nD)";
 
         runQuery(createGraph);
@@ -57,14 +59,14 @@ final class CypherExporterTest extends BaseTest {
 
         //language=Cypher
         String expected =
-                "CREATE (n0:Label1 {foo:bar})\n" +
-                "CREATE (n1:Label1 {property:42.1337})\n" +
-                "CREATE (n2:Label2)\n" +
-                "CREATE (n3)\n" +
-                "CREATE\n" +
-                "  (n0)-[:TYPE1 {property:1337.42}]->(n2),\n" +
-                "  (n0)-[:TYPE1 {bar:baz}]->(n1),\n" +
-                "  (n1)-[:TYPE2]->(n2),\n" +
+                "CREATE (n0:Label1 {foo:bar})" + newLine +
+                "CREATE (n1:Label1 {property:42.1337})" + newLine +
+                "CREATE (n2:Label2)" + newLine +
+                "CREATE (n3)" + newLine +
+                "CREATE" + newLine +
+                "  (n0)-[:TYPE1 {property:1337.42}]->(n2)," + newLine +
+                "  (n0)-[:TYPE1 {bar:baz}]->(n1)," + newLine +
+                "  (n1)-[:TYPE2]->(n2)," + newLine +
                 "  (n2)-[:TYPE]->(n3);";
 
         assertEquals(expected, output.toString().trim());
@@ -74,14 +76,14 @@ final class CypherExporterTest extends BaseTest {
     void testDumpByGraphForHuge() {
         //language=Cypher
         String expected =
-                "CREATE (n0 {property:42.0})\n" +
-                "CREATE (n1 {property:42.1337})\n" +
-                "CREATE (n2 {property:42.0})\n" +
-                "CREATE (n3 {property:42.0})\n" +
-                "CREATE\n" +
-                "  (n0)-[ {weight:42.0}]->(n1),\n" +
-                "  (n0)-[ {weight:1337.42}]->(n2),\n" +
-                "  (n1)-[ {weight:42.0}]->(n2),\n" +
+                "CREATE (n0 {property:42.0})" + newLine +
+                "CREATE (n1 {property:42.1337})" + newLine +
+                "CREATE (n2 {property:42.0})" + newLine +
+                "CREATE (n3 {property:42.0})" + newLine +
+                "CREATE" + newLine +
+                "  (n0)-[ {weight:42.0}]->(n1)," + newLine +
+                "  (n0)-[ {weight:1337.42}]->(n2)," + newLine +
+                "  (n1)-[ {weight:42.0}]->(n2)," + newLine +
                 "  (n2)-[ {weight:42.0}]->(n3);";
 
         String output = dumpGraph();


### PR DESCRIPTION
Some tests were failing on Windows due to differences in CR;LF with
Unix. Replacing the hardcoded '\n' in these tests with a call to
System.lineSeparator() which returns '\n' on Unix and '\r\n' on
Windows fixed the problem.

Partially fixes #195 (fixes the trivial CRLF issues)

