### PR TITLE
chore: Fix compatibility matrix within README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,7 +77,7 @@ If you are using Neo4j Desktop you can simply add the Graph Data Science library
 
 .6+<.^|GDS 2.2.x
 |Neo4j 4.3.15 - 4.3.23
-.16+.^|Java 11 & Java 17
+.17+.^|Java 11 & Java 17
 |Neo4j 4.4.9 - 4.4.16
 |Neo4j 5.1.0
 |Neo4j 5.2.0


### PR DESCRIPTION
The compatibility matrix formatting is wrong for the Java versions - this PR simply adjusts the multi row height to make sure the table rendered right for `Java 11 & Java 17`

Before submitting this PR, please make sure:
- [x] You signed the [Neo4j CLA](https://neo4j.com/developer/cla/#sign-cla) (Contributor License Agreement) so that we are allowed to ship your code in our library
- [x] Your contribution is covered by tests

