### PR TITLE
Broken link updated with a new option for accessing the paper

### DIFF
--- a/doc/modules/ROOT/pages/algorithms/betweenness-centrality.adoc
+++ b/doc/modules/ROOT/pages/algorithms/betweenness-centrality.adoc
@@ -29,7 +29,7 @@ The implementation requires _O(n + m)_ space and runs in _O(n * m)_ time, where 
 
 For more information on this algorithm, see:
 
-* http://snap.stanford.edu/class/cs224w-readings/brandes01centrality.pdf[A Faster Algorithm for Betweenness Centrality^]
+* https://snap.stanford.edu/class/cs224w-readings/brandes01centrality.pdf[A Faster Algorithm for Betweenness Centrality^]
 * https://www.uni-konstanz.de/mmsp/pubsys/publishedFiles/BrPi07.pdf[Centrality Estimation in Large Networks^]
 * http://moreno.ss.uci.edu/23.pdf[A Set of Measures of Centrality Based on Betweenness^]
 

--- a/doc/modules/ROOT/pages/algorithms/betweenness-centrality.adoc
+++ b/doc/modules/ROOT/pages/algorithms/betweenness-centrality.adoc
@@ -29,7 +29,7 @@ The implementation requires _O(n + m)_ space and runs in _O(n * m)_ time, where 
 
 For more information on this algorithm, see:
 
-* https://www.eecs.wsu.edu/~assefaw/CptS580-06/papers/brandes01centrality.pdf[A Faster Algorithm for Betweenness Centrality^]
+* http://snap.stanford.edu/class/cs224w-readings/brandes01centrality.pdf[A Faster Algorithm for Betweenness Centrality^]
 * https://www.uni-konstanz.de/mmsp/pubsys/publishedFiles/BrPi07.pdf[Centrality Estimation in Large Networks^]
 * http://moreno.ss.uci.edu/23.pdf[A Set of Measures of Centrality Based on Betweenness^]
 

--- a/doc/modules/ROOT/pages/machine-learning/node-embeddings/fastrp.adoc
+++ b/doc/modules/ROOT/pages/machine-learning/node-embeddings/fastrp.adoc
@@ -64,7 +64,7 @@ In general, it is recommended to first use `UNDIRECTED` as this is what the orig
 For more information on this algorithm see:
 
 * https://arxiv.org/pdf/1908.11512.pdf[H. Chen, S.F. Sultan, Y. Tian, M. Chen, S. Skiena: Fast and Accurate Network Embeddings via Very Sparse Random Projection, 2019.^]
-* https://core.ac.uk/download/pdf/82724427.pdf[Dimitris Achlioptas. Database-friendly random projections: Johnson-Lindenstrauss with binary coins. Journal of Computer and System Sciences, 66(4):671–687, 2003.]
+* https://www.sciencedirect.com/science/article/pii/S0022000003000254[Dimitris Achlioptas. Database-friendly random projections: Johnson-Lindenstrauss with binary coins. Journal of Computer and System Sciences, 66(4):671–687, 2003.]
 
 
 === Node properties


### PR DESCRIPTION
Updating the link to this paper as the previous link was leading to 404. This was reported on SEMRush.