### PR TITLE
fixed compat matrix table headers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ When installing GDS manually, please refer to the below compatibility matrix:
 
 .Compatibility matrix (italicized version is in development)
 |===
-|GDS version | Neo4j version | Java Version
+|GDS version | Java version | Neo4j Version
 .7+<.^|_GDS 2.7.x_ (preview)
 .4+.^|Java 21 & Java 17
 |Neo4j 5.16.0


### PR DESCRIPTION
The compatibility matrix table headers are mixed up, this MR fixes it.

<img width="617" alt="Screenshot 2024-02-05 at 20 38 19" src="https://github.com/neo4j/graph-data-science/assets/1222009/76be60a6-f0a0-4da7-ae30-e353de357ec2">


