### PR TITLE
Update page-rank.adoc - Error in analysis.

### DIFF
--- a/doc/modules/ROOT/pages/algorithms/page-rank.adoc
+++ b/doc/modules/ROOT/pages/algorithms/page-rank.adoc
@@ -531,8 +531,6 @@ ORDER BY score DESC, name ASC
 --
 
 In this example we are using `tolerance: 0.1`, so the results are a bit different compared to the ones from xref:algorithms/page-rank.adoc#algorithms-page-rank-examples-stream[stream example] which is using the default value of `tolerance`.
-Note that the nodes 'About', 'Link' and 'Product' now have the same score, while with the default value of `tolerance` the node 'Product' has higher score than the other two.
-
 
 [[algorithms-page-rank-examples-damping]]
 === Damping Factor

--- a/doc/modules/ROOT/pages/algorithms/page-rank.adoc
+++ b/doc/modules/ROOT/pages/algorithms/page-rank.adoc
@@ -532,6 +532,7 @@ ORDER BY score DESC, name ASC
 
 In this example we are using `tolerance: 0.1`, so the results are a bit different compared to the ones from xref:algorithms/page-rank.adoc#algorithms-page-rank-examples-stream[stream example] which is using the default value of `tolerance`.
 
+
 [[algorithms-page-rank-examples-damping]]
 === Damping Factor
 
@@ -569,6 +570,7 @@ ORDER BY score DESC, name ASC
 --
 
 Compared to the results from the xref:algorithms/page-rank.adoc#algorithms-page-rank-examples-stream[stream example] which is using the default value of `dampingFactor` the score values are closer to each other when using `dampingFactor: 0.05`.
+
 
 [[algorithms-page-rank-examples-personalised]]
 === Personalised PageRank

--- a/doc/modules/ROOT/pages/algorithms/page-rank.adoc
+++ b/doc/modules/ROOT/pages/algorithms/page-rank.adoc
@@ -571,8 +571,6 @@ ORDER BY score DESC, name ASC
 --
 
 Compared to the results from the xref:algorithms/page-rank.adoc#algorithms-page-rank-examples-stream[stream example] which is using the default value of `dampingFactor` the score values are closer to each other when using `dampingFactor: 0.05`.
-Also, note that the nodes 'About', 'Link' and 'Product' now have the same score, while with the default value of `dampingFactor` the node 'Product' has higher score than the other two.
-
 
 [[algorithms-page-rank-examples-personalised]]
 === Personalised PageRank


### PR DESCRIPTION
Issue: Error in the analysis made in a part of the PageRank Documentation
Criticality: Low
Action taken: Removing the part of the analysis that is wrong.

Description:
In the section on the Tolerance configuration parameter, it is stated:

"Also, note that the nodes 'About', 'Link' and 'Product' now have the same score, while with the default value of `tolerance` the node 'Product' has higher score than the other two."

This statement is false from my understanding. The reason why the node 'Product' had a higher score was ONLY the introduction of `relationshipWeightProperty: 'weight'` in the parameters. In reality, the contrary of the statement can be observed (_equal score for nodes 'About', 'Link' and 'Product'_) in all examples not using _weight_.