### PR TITLE
Fixed windows tests failing due to line separators issues

### DIFF
--- a/applications/graph-store-catalog/src/test/java/org/neo4j/gds/applications/graphstorecatalog/DefaultGraphCatalogApplicationsTest.java
+++ b/applications/graph-store-catalog/src/test/java/org/neo4j/gds/applications/graphstorecatalog/DefaultGraphCatalogApplicationsTest.java
@@ -184,8 +184,8 @@ class DefaultGraphCatalogApplicationsTest {
             null,
             null,
             null
-        )).withMessage("Multiple errors in configuration arguments:\n" +
-            "\t\t\t\tNo value specified for the mandatory configuration parameter `nodeProjection`\n" +
+        )).withMessage("Multiple errors in configuration arguments:" + System.lineSeparator() +
+            "\t\t\t\tNo value specified for the mandatory configuration parameter `nodeProjection`" + System.lineSeparator() +
             "\t\t\t\tNo value specified for the mandatory configuration parameter `relationshipProjection`");
 
         assertThatIllegalArgumentException().isThrownBy(() -> facade.nativeProject(
@@ -259,8 +259,8 @@ class DefaultGraphCatalogApplicationsTest {
             null,
             null,
             null
-        )).withMessage("Multiple errors in configuration arguments:\n" +
-            "\t\t\t\tNo value specified for the mandatory configuration parameter `nodeQuery`\n" +
+        )).withMessage("Multiple errors in configuration arguments:" + System.lineSeparator() +
+            "\t\t\t\tNo value specified for the mandatory configuration parameter `nodeQuery`" + System.lineSeparator() +
             "\t\t\t\tNo value specified for the mandatory configuration parameter `relationshipQuery`");
 
         assertThatIllegalArgumentException().isThrownBy(() -> facade.cypherProject(


### PR DESCRIPTION
Fixed DefaultGraphCatalogApplicationsTest on windows

Some DefaultGraphCatalogApplicationsTest were failing on Windows due to differences in CR;LF with
Unix. Replacing the hardcoded '\n' in these tests with a call to
System.lineSeparator() which returns '\n' on Unix and '\r\n' on
Windows fixed the problem.
