### PR TITLE
Document vector search with GDS node embeddings

### DIFF
--- a/doc/modules/ROOT/pages/machine-learning/node-embeddings/fastrp.adoc
+++ b/doc/modules/ROOT/pages/machine-learning/node-embeddings/fastrp.adoc
@@ -55,6 +55,14 @@ We will return to xref:machine-learning/node-embeddings/fastrp.adoc#algorithms-e
 Therefore, each node's embedding depends on a neighborhood of radius equal to the number of iterations.
 This way FastRP exploits higher-order relationships in the graph while still being highly scalable.
 
+[TIP]
+====
+FastRP embeddings can be used with Neo4j vector search to retrieve nodes with similar graph topology.
+Write the embeddings to node properties, create a Neo4j https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/[vector index] over that property, and query it with Cypher.
+This structural vector search can be useful on its own or combined with full-text and content embedding results in a hybrid search query.
+For a worked lexical, semantic, and structural example, see https://neo4j.com/developer/genai-ecosystem/hybrid-search/[Hybrid search in the Developer Guide].
+====
+
 
 === Node properties
 

--- a/doc/modules/ROOT/pages/machine-learning/node-embeddings/index.adoc
+++ b/doc/modules/ROOT/pages/machine-learning/node-embeddings/index.adoc
@@ -4,7 +4,7 @@
 
 
 Node embedding algorithms compute low-dimensional vector representations of nodes in a graph.
-These vectors, also called embeddings, can be used for machine learning.
+These vectors, also called embeddings, can be used for machine learning and vector search.
 The Neo4j Graph Data Science library contains the following node embedding algorithms:
 
 * Production-quality
@@ -16,13 +16,22 @@ The Neo4j Graph Data Science library contains the following node embedding algor
 ** xref:machine-learning/node-embeddings/hashgnn.adoc[HashGNN]
 
 
+[[node-embeddings-using]]
+== Using node embeddings
+
+Node embeddings support two common workflows:
+
+* Machine learning: Use embeddings as input features for downstream tasks such as node classification, link prediction, and kNN similarity graph construction.
+* Structural similarity search: Write embeddings to node properties, create a Neo4j https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/[vector index] on that property, and retrieve nodes that are similar by graph topology.
+  This structural vector search can be useful on its own or combined with lexical and semantic results in hybrid search.
+
+For a worked lexical, semantic, and structural example, see https://neo4j.com/developer/genai-ecosystem/hybrid-search/[Hybrid search in the Developer Guide].
+
 
 [[node-embeddings-generalization]]
 == Generalization across graphs
 
-Node embeddings are typically used as input to downstream machine learning tasks such as node classification, link prediction and kNN similarity graph construction.
-
-Often the graph used for constructing the embeddings and training the downstream model differs from the graph on which predictions are made.
+In machine learning tasks, often the graph used for constructing the embeddings and training the downstream model differs from the graph on which predictions are made.
 Compared to normal machine learning where we just have a stream of independent examples from some distribution, we now have graphs that are used to generate a set of labeled examples.
 Therefore, we must ensure that the set of training examples is representative of the set of labeled examples derived from the prediction graph.
 For this to work, certain things are required of the embedding algorithm, and we denote such algorithms as _inductive_ footnote:definition[This practical definition of induction may not agree completely with definitions elsewhere].


### PR DESCRIPTION
## Summary

- Add a node embeddings overview section that separates machine learning usage from structural similarity search with Neo4j vector search.
- Add a FastRP callout explaining how written embeddings can be indexed and queried with Neo4j vector search.
- Link to the Developer Guide hybrid-search example for lexical, semantic, and structural fusion.

## Validation

- `git diff --check`
- GDS Antora build passed locally with a temporary playbook adjusted for this checkout layout.
- docs-meta live smoke test passed against `neo4j:latest` / Neo4j `2026.04.0` / GDS `2026.04.0`: created a graph, wrote FastRP embeddings, created a vector index, and queried it with both `db.index.vector.queryNodes()` and Cypher 25 `SEARCH`.
