### PR TITLE
Depend on `TransactionRegistry` interface instead of the implementation

### DIFF
--- a/core/src/integrationTest/java/org/neo4j/gds/TerminationTest.java
+++ b/core/src/integrationTest/java/org/neo4j/gds/TerminationTest.java
@@ -26,7 +26,7 @@ import org.neo4j.gds.core.concurrency.ParallelUtil;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.query.ExecutingQuery;
-import org.neo4j.kernel.impl.api.KernelTransactions;
+import org.neo4j.kernel.impl.api.TransactionRegistry;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,12 +46,12 @@ class TerminationTest extends BaseProcTest {
 
     public static final String QUERY = "CALL test.testProc()";
 
-    private KernelTransactions kernelTransactions;
+    private TransactionRegistry kernelTransactions;
 
     @BeforeEach
     void setup() throws Exception {
         registerProcedures(TerminateProcedure.class);
-        kernelTransactions = resolveDependency(KernelTransactions.class);
+        kernelTransactions = resolveDependency(TransactionRegistry.class);
     }
 
     // terminate a transaction by its id

--- a/cypher-aggregation/src/main/java/org/neo4j/gds/projection/AggregationInitializationHelper.java
+++ b/cypher-aggregation/src/main/java/org/neo4j/gds/projection/AggregationInitializationHelper.java
@@ -24,7 +24,7 @@ import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.procedure.Context;
 import org.neo4j.kernel.database.DatabaseReferenceImpl;
 import org.neo4j.kernel.database.DatabaseReferenceRepository;
-import org.neo4j.kernel.impl.api.KernelTransactions;
+import org.neo4j.kernel.impl.api.TransactionRegistry;
 
 public final class AggregationInitializationHelper {
 
@@ -47,8 +47,8 @@ public final class AggregationInitializationHelper {
         if (runsOnCompositeDatabase) {
             queryProvider = ExecutingQueryProvider.empty();
         } else {
-            assert GraphDatabaseApiProxy.containsDependency(databaseService, KernelTransactions.class);
-            var ktxs = GraphDatabaseApiProxy.resolveDependency(databaseService, KernelTransactions.class);
+            assert GraphDatabaseApiProxy.containsDependency(databaseService, TransactionRegistry.class);
+            var ktxs = GraphDatabaseApiProxy.resolveDependency(databaseService, TransactionRegistry.class);
             queryProvider = ExecutingQueryProvider.fromTransaction(ktxs, transaction);
         }
 

--- a/cypher-aggregation/src/main/java/org/neo4j/gds/projection/AlphaCypherAggregation.java
+++ b/cypher-aggregation/src/main/java/org/neo4j/gds/projection/AlphaCypherAggregation.java
@@ -36,7 +36,7 @@ import org.neo4j.kernel.api.procedure.CallableUserAggregationFunction;
 import org.neo4j.kernel.api.procedure.Context;
 import org.neo4j.kernel.database.DatabaseReferenceImpl;
 import org.neo4j.kernel.database.DatabaseReferenceRepository;
-import org.neo4j.kernel.impl.api.KernelTransactions;
+import org.neo4j.kernel.impl.api.TransactionRegistry;
 import org.neo4j.procedure.Name;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.storable.TextValue;
@@ -92,7 +92,7 @@ public class AlphaCypherAggregation implements CallableUserAggregationFunction {
         var metrics = GraphDatabaseApiProxy.lookupComponentProvider(ctx, Metrics.class, true);
         var username = ctx.kernelTransaction().securityContext().subject().executingUser();
         var transaction = ctx.transaction();
-        var ktxs = GraphDatabaseApiProxy.resolveDependency(databaseService, KernelTransactions.class);
+        var ktxs = GraphDatabaseApiProxy.resolveDependency(databaseService, TransactionRegistry.class);
         var queryProvider = ExecutingQueryProvider.fromTransaction(ktxs, transaction);
 
         var databaseId = GraphDatabaseApiProxy.databaseId(databaseService);

--- a/cypher-aggregation/src/main/java/org/neo4j/gds/projection/ExecutingQueryProvider.java
+++ b/cypher-aggregation/src/main/java/org/neo4j/gds/projection/ExecutingQueryProvider.java
@@ -21,7 +21,7 @@ package org.neo4j.gds.projection;
 
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.impl.api.KernelTransactions;
+import org.neo4j.kernel.impl.api.TransactionRegistry;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 
 import java.util.Optional;
@@ -29,7 +29,7 @@ import java.util.Optional;
 public interface ExecutingQueryProvider {
     Optional<String> executingQuery();
 
-    static ExecutingQueryProvider fromTransaction(KernelTransactions ktxs, Transaction transaction) {
+    static ExecutingQueryProvider fromTransaction(TransactionRegistry ktxs, Transaction transaction) {
         return new TxQuery(ktxs, transaction);
     }
 
@@ -40,10 +40,10 @@ public interface ExecutingQueryProvider {
 
 
 final class TxQuery implements ExecutingQueryProvider {
-    private final KernelTransactions ktxs;
+    private final TransactionRegistry ktxs;
     private final Transaction transaction;
 
-    TxQuery(KernelTransactions ktxs, Transaction transaction) {
+    TxQuery(TransactionRegistry ktxs, Transaction transaction) {
         this.ktxs = ktxs;
         this.transaction = transaction;
     }


### PR DESCRIPTION
In virtual graphs we plan to start using a different implementation of `TransactionRegistry` (and other kernel apis). This change is intended to make GDS work with virtual graphs once that happens.