### PR TITLE
Avoid boxing when summing Pregel messages in PageRank, ArticleRank, Eigenvector

### DIFF
--- a/algo/src/main/java/org/neo4j/gds/pagerank/ArticleRankComputation.java
+++ b/algo/src/main/java/org/neo4j/gds/pagerank/ArticleRankComputation.java
@@ -83,10 +83,7 @@ public final class ArticleRankComputation<C extends ArticleRankConfig> implement
         double delta = rank;
 
         if (!context.isInitialSuperstep()) {
-            double sum = 0;
-            for (var message : messages) {
-                sum += message;
-            }
+            double sum = messages.isEmpty() ? 0 : messages.doubleIterator().nextDouble();
             delta = dampingFactor * sum;
             context.setNodeValue(PAGE_RANK, rank + delta);
         }

--- a/algo/src/main/java/org/neo4j/gds/pagerank/EigenvectorComputation.java
+++ b/algo/src/main/java/org/neo4j/gds/pagerank/EigenvectorComputation.java
@@ -100,8 +100,8 @@ public final class EigenvectorComputation<C extends EigenvectorConfig> implement
         // more distinguishable.
         double nextRank = context.doubleNodeValue(RANK);
 
-        for (var message : messages) {
-            nextRank += message;
+        if (!messages.isEmpty()) {
+            nextRank += messages.doubleIterator().nextDouble();
         }
 
         // The degree function returns either 1 if the graph is unweighted

--- a/algo/src/main/java/org/neo4j/gds/pagerank/PageRankComputation.java
+++ b/algo/src/main/java/org/neo4j/gds/pagerank/PageRankComputation.java
@@ -80,10 +80,7 @@ public final class PageRankComputation<C extends PageRankConfig> implements Preg
         double delta = rank;
 
         if (!context.isInitialSuperstep()) {
-            double sum = 0;
-            for (var message : messages) {
-                sum += message;
-            }
+            double sum = messages.isEmpty() ? 0 : messages.doubleIterator().nextDouble();
             delta = dampingFactor * sum;
             context.setNodeValue(PAGE_RANK, rank + delta);
         }


### PR DESCRIPTION
PageRankComputation, ArticleRankComputation, and EigenvectorComputation sum incoming messages via a for-each over Messages (Iterable<Double>), which boxes each value through MessageIterator's default Iterator<Double>#next(). All three register Reducer.Sum, so at most one message is ever delivered per node per superstep. This switches the summation to messages.doubleIterator().nextDouble(), matching the pattern already used in TriangleCountPregel and IndirectExposureComputation.

No behavior change. PageRankTest passes unmodified.